### PR TITLE
Add replacement tokens

### DIFF
--- a/src/PluginModal.ts
+++ b/src/PluginModal.ts
@@ -20,6 +20,19 @@ export class PluginModal extends Modal {
 	generateButton: ButtonComponent;
 	promptField: TextAreaComponent;
 
+	replacementTokens = {
+		selection: (match: RegExpMatchArray, prompt: string) => {
+			const view =
+				this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			if (view) {
+				const selection = view.editor.getSelection();
+				prompt = this.replaceToken(match, prompt, selection);
+			}
+
+			return prompt;
+		},
+	};
+
 	constructor(private plugin: GPT3Notes) {
 		super(plugin.app);
 	}
@@ -62,6 +75,11 @@ export class PluginModal extends Modal {
 
 		this.tokenSection(dropdownsDiv, "Prefix", data.prefix);
 		this.tokenSection(dropdownsDiv, "Postfix", data.postfix);
+		this.tokenSection(
+			dropdownsDiv,
+			"Tokens",
+			Object.keys(this.replacementTokens).map((key) => `{{${key}}}`)
+		);
 
 		this.promptField = new TextAreaComponent(container);
 		this.promptField.inputEl.className = "gpt_prompt-field";
@@ -161,21 +179,17 @@ export class PluginModal extends Modal {
 		this.prompt = item.prompt;
 	}
 
-	replaceToken(match: RegExpMatchArray, prompt: string, replacementText: string) {
+	replaceToken(
+		match: RegExpMatchArray,
+		prompt: string,
+		replacementText: string
+	) {
 		const matchIndex = match.index || 0;
-		return prompt.substring(0, matchIndex) + replacementText + prompt.substring(matchIndex + match[0].length)
-	}
-
-	replacementTokens = {
-		selection: (match: RegExpMatchArray, prompt: string) => {
-			const view = this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
-			if (view) {
-				const selection = view.editor.getSelection();
-				prompt = this.replaceToken(match, prompt, selection);
-			}
-
-			return prompt;
-		},
+		return (
+			prompt.substring(0, matchIndex) +
+			replacementText +
+			prompt.substring(matchIndex + match[0].length)
+		);
 	}
 
 	processReplacementTokens(prompt: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type GPT3ModelParams = {
 };
 export type GPTHistoryItem = {
 	prompt: string;
+	processedPrompt: string;
 	temperature: number;
 	tokens: number;
 };


### PR DESCRIPTION
Adds a token dropdown that allows using the current selection in the middle of a prompt.

![image](https://user-images.githubusercontent.com/472791/212060002-d1777126-86a8-4706-b4a1-b1306f32f38e.png)

It should be relatively easy to add new tokens with other functionality, like adding the whole document (although that may require cutting the text due to OpenAI's character limit).
The CSS seems to be broken currently (no CSS file) so I added some styles directly.

Should solve #2 